### PR TITLE
Remove simple links from data when parsed

### DIFF
--- a/lib/sawyer/link_parsers/simple.rb
+++ b/lib/sawyer/link_parsers/simple.rb
@@ -17,7 +17,7 @@ module Sawyer
         inline_links = data.keys.select {|k| k.to_s[LINK_REGEX] }
         inline_links.each do |key|
           rel_name = key.to_s == 'url' ? 'self' : key.to_s.gsub(LINK_REGEX, '')
-          links[rel_name.to_sym] = data[key]
+          links[rel_name.to_sym] = data.delete(key)
         end
 
         return data, links

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -131,9 +131,12 @@ module Sawyer
 
       assert_equal '/', res.rels[:self].href
       assert_kind_of Resource, res.user
+      assert !res.fields.include?(:url)
       assert_equal 1, res.user.id
       assert_equal '/users/1', res.user.rels[:self].href
+      assert !res.user.fields.include?(:url)
       assert_equal '/users/1/followers', res.user.rels[:followers].href
+      assert !res.user.fields.include?(:followers_url)
     end
   end
 end


### PR DESCRIPTION
`*_url` links are removed from `Resource#data` when parsed to be consistent with the HAL parser behavior.
