### PR TITLE
Process Link response headers for responses

### DIFF
--- a/lib/sawyer/response.rb
+++ b/lib/sawyer/response.rb
@@ -16,6 +16,7 @@ module Sawyer
       @headers = res.headers
       @env     = res.env
       @data    = process_data(@agent.decode_body(res.body))
+      @rels    = process_rels
     end
 
     # Turns parsed contents from an API response into a Resource or
@@ -31,6 +32,19 @@ module Sawyer
       when nil   then nil
       else data
       end
+    end
+
+    # Finds link relations from 'Link' response header
+    #
+    # Returns an array of Relations
+    def process_rels
+      links = ( @headers["Link"] || "" ).split(', ').map do |link|
+        href, name = link.match(/<(.*?)>; rel="(\w+)"/).captures
+
+        [name.to_sym, Relation.from_link(@agent, name, :href => href)]
+      end
+
+      Hash[*links.flatten]
     end
 
     def timing

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -9,7 +9,10 @@ module Sawyer
         conn.builder.handlers.delete(Faraday::Adapter::NetHttp)
         conn.adapter :test, @stubs do |stub|
           stub.get '/' do
-            [200, {'Content-Type' => 'application/json'}, Sawyer::Agent.encode(
+            [200, {
+              'Content-Type' => 'application/json',
+              'Link' =>  '</starred?page=2>; rel="next", </starred?page=19>; rel="last"'
+              }, Sawyer::Agent.encode(
               :a => 1,
               :_links => {
                 :self => {:href => '/a', :method => 'POST'}
@@ -42,6 +45,10 @@ module Sawyer
     end
 
     def test_gets_rels
+      assert_equal '/starred?page=2', @res.rels[:next].href
+      assert_equal :get, @res.rels[:next].method
+      assert_equal '/starred?page=19', @res.rels[:last].href
+      assert_equal :get, @res.rels[:next].method
       assert_equal '/a',  @res.data.rels[:self].href
       assert_equal :post, @res.data.rels[:self].method
     end


### PR DESCRIPTION
Relations in the `Link` header are now properly instantiated as
`Sawyer::Relation` when an HTTP response is processed.
