### PR TITLE
Support YAML.dump and YAML.load for Agent objects

### DIFF
--- a/lib/sawyer/agent.rb
+++ b/lib/sawyer/agent.rb
@@ -140,6 +140,12 @@ module Sawyer
     def inspect
       %(<#{self.class} #{@endpoint}>)
     end
+
+    # private
+    def to_yaml_properties
+      [:@endpoint]
+    end
+
   end
 end
 

--- a/test/agent_test.rb
+++ b/test/agent_test.rb
@@ -149,6 +149,14 @@ module Sawyer
 
       assert_equal "This is plain text", res.data
     end
+
+    def test_handle_yaml_dump_and_load
+      assert_nothing_raised do
+        require 'yaml'
+        res = Agent.new 'http://example.com', :a => 1
+        YAML.load(YAML.dump(res))
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Hey @lostisland,

The changes in this pull request ensure instances of `Sawyer::Agent` can be correctly dumped to YAML, and loaded back in from YAML.

They are similar to the changes in [this commit](https://github.com/lostisland/sawyer/commit/c706f111644ba4c8d074c8f83967afc950335094), which did something similar for instances of `Sawyer::Resources`

Thanks,

@pvdb
