### PR TITLE
Add raw response body to Sawyer::Response

### DIFF
--- a/lib/sawyer/response.rb
+++ b/lib/sawyer/response.rb
@@ -3,6 +3,7 @@ module Sawyer
     attr_reader :agent,
       :status,
       :headers,
+      :body,
       :data,
       :rels
 
@@ -15,7 +16,8 @@ module Sawyer
       @status  = res.status
       @headers = res.headers
       @env     = res.env
-      @data    = @headers[:content_type] =~ /json|msgpack/ ? process_data(@agent.decode_body(res.body)) : res.body
+      @body    = res.body
+      @data    = @headers[:content_type] =~ /json|msgpack/ ? process_data(@agent.decode_body(body)) : body
       @rels    = process_rels
       @started = options[:sawyer_started]
       @ended   = options[:sawyer_ended]


### PR DESCRIPTION
I recently had need of the raw body when working with Octokit without any of the filtering or processing from Sawyer. I ended up with a little monkey patch that essentially did what this PR does. All tests are green. 

Thanks for a great project!
## 

Provides access to the raw response body as `Response#body`. The addition of
the response body gives added symmetry to the reponse object since we can
get to the headers, status, env, etc.
