### PR TITLE
Add Resource#to_h alias

### DIFF
--- a/lib/sawyer/resource.rb
+++ b/lib/sawyer/resource.rb
@@ -4,6 +4,7 @@ module Sawyer
     attr_reader :_agent, :_rels, :_fields
     attr_reader :attrs
     alias to_hash attrs
+    alias to_h attrs
 
     # Initializes a Resource with the given data.
     #


### PR DESCRIPTION
I've found it really useful to be able to call #to_h on a resource now that Ruby's NilClass [supports #to_h](http://ruby-doc.org/core-2.0/NilClass.html#method-i-to_h). So it doesn't matter if the resource is available or not, I always get a hash and can avoid adding conditionals.
