### PR TITLE
Fix problem with unmarshalled resources

### DIFF
--- a/lib/sawyer/resource.rb
+++ b/lib/sawyer/resource.rb
@@ -127,6 +127,7 @@ module Sawyer
 
     def marshal_load(dumped)
       @attrs, @_fields, @_rels = *dumped.shift(3)
+      @_metaclass = (class << self; self; end)
     end
   end
 end

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -166,8 +166,9 @@ module Sawyer
 
     def test_handle_marshal_dump
       assert_nothing_raised do
-        res = Resource.new @agent, :a => 1
-        Marshal.dump(res)
+        dump = Marshal.dump(Resource.new(@agent, :a => 1))
+        resource = Marshal.load(dump)
+        assert_equal 1, resource.a
       end
     end
   end


### PR DESCRIPTION
Calling methods on the loaded resource would raise `NoMethodError: undefined method attr_accessor for nil:NilClass`.
