### PR TITLE
rescue exception when time_field is an integer

### DIFF
--- a/lib/sawyer/serializer.rb
+++ b/lib/sawyer/serializer.rb
@@ -104,6 +104,8 @@ module Sawyer
           Time.parse(value)
         rescue ArgumentError
           value
+        rescue TypeError
+          value
         end
       elsif value.is_a?(Hash)
         decode_hash(value)

--- a/test/agent_test.rb
+++ b/test/agent_test.rb
@@ -127,6 +127,7 @@ module Sawyer
         :published_at => nil,
         :updated_at => "An invalid date",
         :pub_date => time,
+        :deleted_at => time.to_i,
         :validate => true
       }
       data = [data.merge(:foo => [data])]


### PR DESCRIPTION
Time.parse raise TypeError exception if it's first argument is an integer. This happen when we return time_field as timestamp integer.
