### PR TITLE
Buxfix when time_field is not string

### DIFF
--- a/lib/sawyer/serializer.rb
+++ b/lib/sawyer/serializer.rb
@@ -99,10 +99,16 @@ module Sawyer
     end
 
     def decode_hash_value(key, value)
-      if value.is_a?(String) && time_field?(key, value)
-        begin
-          Time.parse(value)
-        rescue ArgumentError
+      if time_field?(key, value)
+        if value.is_a?(String)
+          begin
+            Time.parse(value)
+          rescue ArgumentError
+            value
+          end
+        elsif value.is_a?(Integer) || value.is_a?(Float)
+          Time.at(value)
+        else
           value
         end
       elsif value.is_a?(Hash)

--- a/test/agent_test.rb
+++ b/test/agent_test.rb
@@ -148,6 +148,9 @@ module Sawyer
         assert_equal "An invalid date", decoded[:updated_at]
         assert_equal time, decoded[:pub_date], "Did not parse pub_date as Time"
         assert_equal true, decoded[:validate]
+        assert_equal time, decoded[:subscribed_at], "Did not parse subscribed_at as Time"
+        assert_equal time, decoded[:lost_at], "Did not parse lost_at as Time"
+        assert_equal false, decoded[:first_date], "Parsed first_date"
         decoded = decoded[:foo]
       end
     end


### PR DESCRIPTION
Don't parse non string value as time.
