### PR TITLE
Clone instead of move _url fields with the simple link parser

### DIFF
--- a/lib/sawyer/link_parsers/simple.rb
+++ b/lib/sawyer/link_parsers/simple.rb
@@ -17,7 +17,7 @@ module Sawyer
         inline_links = data.keys.select {|k| k.to_s[LINK_REGEX] }
         inline_links.each do |key|
           rel_name = key.to_s == 'url' ? 'self' : key.to_s.gsub(LINK_REGEX, '')
-          links[rel_name.to_sym] = data.delete(key)
+          links[rel_name.to_sym] = data[key]
         end
 
         return data, links

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -148,12 +148,12 @@ module Sawyer
 
       assert_equal '/', res.rels[:self].href
       assert_kind_of Resource, res.user
-      assert !res.fields.include?(:url)
+      assert_equal '/', res.url
       assert_equal 1, res.user.id
       assert_equal '/users/1', res.user.rels[:self].href
-      assert !res.user.fields.include?(:url)
+      assert_equal '/users/1', res.user.url
       assert_equal '/users/1/followers', res.user.rels[:followers].href
-      assert !res.user.fields.include?(:followers_url)
+      assert_equal '/users/1/followers', res.user.followers_url
     end
 
     def test_handle_yaml_dump


### PR DESCRIPTION
Fixes issues with data like this:

```
{
  "config": {
    "some_configured_url": "http://example.com"
  }
}
```

Currently, this 'real' url is buried behind `resource.config.rels[:some_configured].href`. Now they're copied, so it'll still be available at `resourece.config.some_configured_url`.

Fixes issues with octokit when fetching webhooks (the example above) and statuses (which have a `target_url`).
