### PR TITLE
fix deserialization problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor/gems
 .bundle
 Gemfile.lock
 bin
+.DS_Store


### PR DESCRIPTION
the Sawyer::Resource has serialization problem, for example: Rails.cache.write the instance of  Resource class, then I read it from the cache, when i invoke the resource's method, it will raise Error, like 'dont have attr_accessor for nil class', or another error about nil class. I check the source code, and found when deserialization the resource instance, it's @_metaclass didn't initialize -- it was nil, this cause the problem. So I changed @_metaclass to a method, and the problem resolved.
