### PR TITLE
Fix #head and #get helpers on Relation using the default method

### DIFF
--- a/lib/sawyer/relation.rb
+++ b/lib/sawyer/relation.rb
@@ -143,7 +143,7 @@ module Sawyer
     def head(options = nil)
       options ||= {}
       options[:method] = :head
-      call options
+      call nil, options
     end
 
     # Public: Makes an API request with the curent Relation using GET.
@@ -160,7 +160,7 @@ module Sawyer
     def get(options = nil)
       options ||= {}
       options[:method] = :get
-      call options
+      call nil, options
     end
 
     # Public: Makes an API request with the curent Relation using POST.
@@ -252,6 +252,8 @@ module Sawyer
     #           :headers - Hash of API headers to set.
     #           :query   - Hash of URL query params to set.
     #           :method  - Symbol HTTP method.
+    #                      If this option is specified, data must be explicitly
+    #                      provided, even for :get and :head requests.
     #
     # Raises ArgumentError if the :method value is not in @available_methods.
     # Returns a Sawyer::Response.


### PR DESCRIPTION
Specifying the method to #call without a body is ambiguous, so that
method's documentation has been updated to reflect actual behavior.

A user could theoretically set up a Relation with a default method of POST for an endpoint that expects a method value in a body being serialized from a hash. I'm not sure there's a way to differentiate that case from someone trying to specify a body-less method type in the options hash that doesn't violate the principle of least surprise in at least some cases.
