### PR TITLE
Eliminate lib/sawyer/resource.rb:90: warning: mismatched indentations at...

### DIFF
--- a/lib/sawyer/resource.rb
+++ b/lib/sawyer/resource.rb
@@ -83,11 +83,11 @@ module Sawyer
       elsif attr_name && @_fields.include?(attr_name.to_sym)
         value = @attrs[attr_name.to_sym]
         case suffix
-             when nil
-               @_metaclass.send(:attr_accessor, attr_name)
-               value
-             when ATTR_PREDICATE then !!value
-             end
+        when nil
+          @_metaclass.send(:attr_accessor, attr_name)
+          value
+        when ATTR_PREDICATE then !!value
+        end
       elsif suffix.nil? && SPECIAL_METHODS.include?(attr_name)
         instance_variable_get "@_#{attr_name}"
       elsif attr_name && !@_fields.include?(attr_name.to_sym)
@@ -144,4 +144,3 @@ module Sawyer
     end
   end
 end
-


### PR DESCRIPTION
... end with case at 85

my environment:

``` ruby
$ ruby -v
ruby 2.1.2p95 (2014-05-08 revision 45877) [x86_64-darwin13.0]
```
