### PR TITLE
Strip response bodies before attempting to decode them

### DIFF
--- a/lib/sawyer/agent.rb
+++ b/lib/sawyer/agent.rb
@@ -122,7 +122,7 @@ module Sawyer
     #
     # Returns an Object resource (Hash by default).
     def decode_body(str)
-      @serializer.decode(str.nil? ? nil : str.strip)
+      @serializer.decode(str)
     end
 
     def parse_links(data)

--- a/lib/sawyer/serializer.rb
+++ b/lib/sawyer/serializer.rb
@@ -58,7 +58,7 @@ module Sawyer
     #
     # Returns a decoded Object.
     def decode(data)
-      return nil if data.nil? || data.empty?
+      return nil if data.nil? || data.strip.empty?
       decode_object(@load.call(data))
     end
 


### PR DESCRIPTION
@pengwynn and @technoweenie for review
# The Problem

When returning responses with no body, like 404s etc. a blank space is sometimes returned. When this happens a `JSON::ParserError` is raised quoting `unexpected token at ''`

In one particular case, using `head(:not_found)` in a rails app added this _blank_ response body which is how I came across this issue.
# Solution

Strip the response body if it's not `nil` before attempting to decode it with a serializer. I've done this in the call from `Agent#decode_body`, though this could be done in `Serializer#decode` if preferred.
