### PR TITLE
Raw response access for Sawyer::Response

### DIFF
--- a/lib/sawyer/response.rb
+++ b/lib/sawyer/response.rb
@@ -3,7 +3,8 @@ module Sawyer
     attr_reader :agent,
       :status,
       :headers,
-      :data,
+      :env,
+      :body,
       :rels
 
     # Builds a Response after a completed request.
@@ -15,10 +16,17 @@ module Sawyer
       @status  = res.status
       @headers = res.headers
       @env     = res.env
-      @data    = @headers[:content_type] =~ /json|msgpack/ ? process_data(@agent.decode_body(res.body)) : res.body
+      @body    = res.body
       @rels    = process_rels
       @started = options[:sawyer_started]
       @ended   = options[:sawyer_ended]
+    end
+
+    def data
+      @data ||= begin
+        return(body) unless (headers[:content_type] =~ /json|msgpack/) 
+        process_data(agent.decode_body(body))
+      end
     end
 
     # Turns parsed contents from an API response into a Resource or
@@ -58,7 +66,7 @@ module Sawyer
     end
 
     def inspect
-      %(#<#{self.class}: #{@status} @rels=#{@rels.inspect} @data=#{@data.inspect}>)
+      %(#<#{self.class}: #{@status} @rels=#{@rels.inspect} @data=#{data.inspect}>)
     end
   end
 end

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -39,6 +39,15 @@ module Sawyer
       assert_equal 'application/json', @res.headers['content-type']
     end
 
+    def test_gets_env
+      assert_equal :get, @res.env.method
+    end
+
+    def test_gets_raw_body
+      assert_kind_of String, @res.body
+      assert (@res.body =~ /^\{/)
+    end
+
     def test_gets_body
       assert_equal 1, @res.data.a
       assert_equal [:a], @res.data.fields.to_a


### PR DESCRIPTION
Sawyer::Response now exposes #env and #body for accessing raw request data. #data itself now memoizes when first called, rather than handling the response decoding in #initialize.

Sometimes, you just need access to the raw data. In my case, I've got some slightly oddball JSON processing to do, plus some Faraday middleware that stores resuls in `response.env`.
