### PR TITLE
Test and fix for the #to_attrs method of Sawyer::Resource

### DIFF
--- a/lib/sawyer/resource.rb
+++ b/lib/sawyer/resource.rb
@@ -130,6 +130,8 @@ module Sawyer
       hash.keys.each do |k|
         if hash[k].is_a?(Sawyer::Resource)
           hash[k] = hash[k].to_attrs
+        elsif hash[k].is_a?(Array) && hash[k].all?{|el| el.is_a?(Sawyer::Resource)}
+          hash[k] = hash[k].collect{|el| el.to_attrs}          
         end
       end
       hash

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -127,6 +127,12 @@ module Sawyer
       hash = {:a => 1 }
       assert_equal hash, res.to_h
     end
+    
+    def test_to_attrs_for_sawyer_resource_arrays
+      res = Resource.new @agent, :a => 1, :b => [Resource.new(@agent, :a => 2)]
+      hash = {:a => 1, :b => [{:a => 2}]}
+      assert_equal hash, res.to_attrs
+    end
 
     def test_handle_hash_notation_with_string_key
       res = Resource.new @agent, :a => 1


### PR DESCRIPTION
If a Resource has an attribute that is an Array of Resources, calling #to_attrs would not recursively call #to_attrs on the elements of the Array. Thus, the returned Hash would also include an Array of Resources instead of an Array of Hashes.
