### PR TITLE
Alias Resource#to_h to #to_attrs instead of #attrs

### DIFF
--- a/lib/sawyer/resource.rb
+++ b/lib/sawyer/resource.rb
@@ -3,8 +3,6 @@ module Sawyer
     SPECIAL_METHODS = Set.new(%w(agent rels fields))
     attr_reader :_agent, :_rels, :_fields
     attr_reader :attrs
-    alias to_hash attrs
-    alias to_h attrs
     include Enumerable
 
     # Initializes a Resource with the given data.
@@ -141,6 +139,9 @@ module Sawyer
       end
       hash
     end
+
+    alias to_hash to_attrs
+    alias to_h to_attrs
 
     def marshal_dump
       [@attrs, @_fields, @_rels]

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -128,6 +128,12 @@ module Sawyer
       assert_equal hash, res.to_h
     end
 
+    def test_to_h_with_nesting
+      res = Resource.new @agent, :a => {:b => 1}
+      hash = {:a => {:b => 1}}
+      assert_equal hash, res.to_h
+    end
+
     def test_to_attrs_for_sawyer_resource_arrays
       res = Resource.new @agent, :a => 1, :b => [Resource.new(@agent, :a => 2)]
       hash = {:a => 1, :b => [{:a => 2}]}


### PR DESCRIPTION
Using `#attrs` returns nested hashes as intances of `Resource` instead of `Hash` which can cause problems when passing the result to `JSON.dump`.