### PR TITLE
upgrade to addressable 2.4.0

### DIFF
--- a/sawyer.gemspec
+++ b/sawyer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.licenses = ['MIT']
 
   spec.add_dependency 'faraday',      ['~> 0.8', '< 0.10']
-  spec.add_dependency 'addressable', ['~> 2.3.5']
+  spec.add_dependency 'addressable', ['~> 2.4.0']
 
   spec.files = %w(Gemfile LICENSE.md README.md Rakefile)
   spec.files << "#{lib}.gemspec"


### PR DESCRIPTION
I tried to include the pronto gem to our project and failed since we have the latest addressable (2.4.0) in use. This is excluded in sawyer. So It would be cool if you can pull and upgrade to 2.4.0.