### PR TITLE
Loosen Addressable dependency again

### DIFF
--- a/sawyer.gemspec
+++ b/sawyer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.licenses = ['MIT']
 
   spec.add_dependency 'faraday',      ['~> 0.8', '< 0.10']
-  spec.add_dependency 'addressable', ['>= 2.3.5', '< 2.5']
+  spec.add_dependency 'addressable', ['>= 2.3.5', '< 2.6']
 
   spec.files = %w(Gemfile LICENSE.md README.md Rakefile)
   spec.files << "#{lib}.gemspec"


### PR DESCRIPTION
Addressable 2.5.0 has been released: https://github.com/sporkmonger/addressable/blob/master/CHANGELOG.md#addressable-250

This loosens up the requirement in the gemspec for it so everyone can enjoy the new version.

🐱 