### PR TITLE
Loosen faraday requirements to allow 0.10 to be picked up

### DIFF
--- a/sawyer.gemspec
+++ b/sawyer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/lostisland/sawyer'
   spec.licenses = ['MIT']
 
-  spec.add_dependency 'faraday',      ['~> 0.8', '< 0.10']
+  spec.add_dependency 'faraday',      ['~> 0.8', '< 1.0']
   spec.add_dependency 'addressable', ['>= 2.3.5', '< 2.6']
 
   spec.files = %w(Gemfile LICENSE.md README.md Rakefile)


### PR DESCRIPTION
Used a similar upper version to what @mislav did in https://github.com/lostisland/faraday_middleware/commit/6532e65c3e25ce8bdf884d118602a41efc0d42e3#diff-2c97a3fba04553020532f4508b0b3bb4