### PR TITLE
Avoid psych deprecation warnings

### DIFF
--- a/lib/sawyer/agent.rb
+++ b/lib/sawyer/agent.rb
@@ -143,6 +143,10 @@ module Sawyer
     end
 
     # private
+    
+    def encode_with(coder)
+    end
+    
     def to_yaml_properties
       [:@endpoint]
     end

--- a/lib/sawyer/resource.rb
+++ b/lib/sawyer/resource.rb
@@ -128,6 +128,9 @@ module Sawyer
       [:@attrs, :@_fields, :@_rels]
     end
 
+    def encode_with(coder)
+    end
+
     def to_attrs
       hash = self.attrs.clone
       hash.keys.each do |k|


### PR DESCRIPTION
This PR avoids two tiny deprecation warnings when running the `rake` tests.

It only adds empty methods for:

```ruby
    def encode_with(coder)
    end
```