### PR TITLE
Travis: add JRuby 9.1.15.0, 2.4.3 to CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: ruby
 
 rvm:
-  - jruby-9.1.13.0
+  - jruby-9.1.14.0
   - 2.0
   - 2.1
   - 2.2
   - 2.3.1
-  - 2.4.0-preview3
+  - 2.4.1
 
 bundler_args: --without development
 
@@ -14,10 +14,10 @@ sudo: false
 
 matrix:
   include:
-    - rvm: jruby-9.1.13.0
+    - rvm: jruby-9.1.14.0
       jdk: oraclejdk8
   allow_failures:
-    - rvm: jruby-9.1.13.0
+    - rvm: jruby-9.1.14.0
       jdk: oraclejdk8
 notifications:
   emails: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: ruby
 
 rvm:
-  - jruby-9.1.14.0
+  - jruby-9.1.15.0
   - 2.0
   - 2.1
   - 2.2
-  - 2.3.1
-  - 2.4.1
+  - 2.3.6
+  - 2.4.3
 
 bundler_args: --without development
 
@@ -14,10 +14,10 @@ sudo: false
 
 matrix:
   include:
-    - rvm: jruby-9.1.14.0
+    - rvm: jruby-9.1.15.0
       jdk: oraclejdk8
   allow_failures:
-    - rvm: jruby-9.1.14.0
+    - rvm: jruby-9.1.15.0
       jdk: oraclejdk8
 notifications:
   emails: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - jruby-9.1.6.0
+  - jruby-9.1.13.0
   - 2.0
   - 2.1
   - 2.2
@@ -14,10 +14,10 @@ sudo: false
 
 matrix:
   include:
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.13.0
       jdk: oraclejdk8
   allow_failures:
-    - rvm: jruby-9.1.6.0
+    - rvm: jruby-9.1.13.0
       jdk: oraclejdk8
 notifications:
   emails: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,23 @@
 language: ruby
 
 rvm:
-  - jruby
-  - rbx-2
+  - jruby-9.1.6.0
   - 2.0
   - 2.1
   - 2.2
+  - 2.3.1
+  - 2.4.0-preview3
 
 bundler_args: --without development
 
 sudo: false
 
 matrix:
+  include:
+    - rvm: jruby-9.1.6.0
+      jdk: oraclejdk8
   allow_failures:
-    - rvm: rbx-2
-    - rvm: jruby
-
+    - rvm: jruby-9.1.6.0
+      jdk: oraclejdk8
 notifications:
   emails: false


### PR DESCRIPTION
This PR adds latest stable JRuby to the build. It also adds 2.4.3, and drops the never-succeeding rbx-2.

http://jruby.org/2017/12/07/jruby-9-1-15-0.html