### PR TITLE
Option to get raw response body

### DIFF
--- a/lib/sawyer/agent.rb
+++ b/lib/sawyer/agent.rb
@@ -78,8 +78,9 @@ module Sawyer
     #           requests can have no body, so this can be the options Hash
     #           instead.
     # options - Hash of option to configure the API request.
-    #           :headers - Hash of API headers to set.
-    #           :query   - Hash of URL query params to set.
+    #           :headers  - Hash of API headers to set.
+    #           :query    - Hash of URL query params to set.
+    #           :raw_body - Boolean to process response body or keep it raw. Default to false
     #
     # Returns a Sawyer::Response.
     def call(method, url, data = nil, options = nil)
@@ -104,7 +105,7 @@ module Sawyer
         started = Time.now
       end
 
-      Response.new self, res, :sawyer_started => started, :sawyer_ended => Time.now
+      Response.new self, res, :sawyer_started => started, :sawyer_ended => Time.now, :raw_body => (options[:raw_body] || false)
     end
 
     # Encodes an object to a string for the API request.

--- a/lib/sawyer/response.rb
+++ b/lib/sawyer/response.rb
@@ -15,7 +15,7 @@ module Sawyer
       @status  = res.status
       @headers = res.headers
       @env     = res.env
-      @data    = @headers[:content_type] =~ /json|msgpack/ ? process_data(@agent.decode_body(res.body)) : res.body
+      @data    = @headers[:content_type] =~ /json|msgpack/ && !options[:raw_body] ? process_data(@agent.decode_body(res.body)) : res.body
       @rels    = process_rels
       @started = options[:sawyer_started]
       @ended   = options[:sawyer_ended]


### PR DESCRIPTION
I came up with a use case when I need raw response body.  In spite of headers set to some certain media type, response body was containing some marshalled data which was not been parsed. So in case we need to get raw body to process ourself. 