### PR TITLE
Raise exception if none of json libraries could be required.

### DIFF
--- a/lib/sawyer/serializer.rb
+++ b/lib/sawyer/serializer.rb
@@ -4,13 +4,9 @@ require 'time'
 module Sawyer
   class Serializer
     def self.any_json
-      serializer = yajl || multi_json || json
-
-      if not serializer
-        raise RuntimeError, "'json' library is need but could not be required"
+      yajl || multi_json || json || begin
+        raise RuntimeError, "Sawyer requires a JSON gem: yajl, multi_json, or json"
       end
-
-      serializer
     end
 
     def self.yajl

--- a/lib/sawyer/serializer.rb
+++ b/lib/sawyer/serializer.rb
@@ -4,7 +4,13 @@ require 'time'
 module Sawyer
   class Serializer
     def self.any_json
-      yajl || multi_json || json
+      serializer = yajl || multi_json || json
+
+      if not serializer
+        raise RuntimeError, "'json' library is need but could not be required"
+      end
+
+      serializer
     end
 
     def self.yajl


### PR DESCRIPTION
Instead of returning nil and let it break in another place, raise
exception as soon as thing goes wrong.