### PR TITLE
Loosen addressable gem to allow 2.6 version 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 
 rvm:
   - jruby
@@ -6,10 +7,8 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-
-bundler_args: --without development
-
-sudo: false
+  - 2.3
+  - 2.4
 
 matrix:
   allow_failures:

--- a/sawyer.gemspec
+++ b/sawyer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.licenses = ['MIT']
 
   spec.add_dependency 'faraday',      ['~> 0.8', '< 1.0']
-  spec.add_dependency 'addressable', ['>= 2.3.5', '< 2.6']
+  spec.add_dependency 'addressable', ['>= 2.3.5', '< 2.7']
 
   spec.files = %w(Gemfile LICENSE.md README.md Rakefile)
   spec.files << "#{lib}.gemspec"


### PR DESCRIPTION
Version 2.6 was released and the changelog looks pretty straight
forward.
https://github.com/sporkmonger/addressable/blob/master/CHANGELOG.md#addressable-260.