### PR TITLE
update relation tests to pass options for get/head/delete requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
+.bundle
+.ruby-version
+bin
+Gemfile.lock
 pkg
 vendor/cache
 vendor/gems
-.bundle
-Gemfile.lock
-bin

--- a/lib/sawyer/relation.rb
+++ b/lib/sawyer/relation.rb
@@ -38,6 +38,7 @@ module Sawyer
       def keys
         @map.keys
       end
+
       def to_hash
         pairs = @map.map do |k, v|
           [(k.to_s + "_url").to_sym, v.href]

--- a/test/relation_test.rb
+++ b/test/relation_test.rb
@@ -73,18 +73,12 @@ module Sawyer
         conn.builder.handlers.delete(Faraday::Adapter::NetHttp)
         conn.adapter :test do |stubs|
           stubs.get '/a/1' do |env|
-            if env.request_headers['Foo'] == 'Bar'
-              [200, {}, '{}']
-            else
-              [400, {}, '{}']
-            end
+            assert_equal 'Bar', env.request_headers['Foo']
+            [200, {}, '{}']
           end
           stubs.delete '/a/1' do |env|
-            if env.request_headers['Foo'] == 'Bar'
-              [204, {}, '{}']
-            else
-              [400, {}, '{}']
-            end
+            assert_equal 'Bar', env.request_headers['Foo']
+            [204, {}, '{}']
           end
         end
       end

--- a/test/relation_test.rb
+++ b/test/relation_test.rb
@@ -177,7 +177,7 @@ module Sawyer
       rel  = Sawyer::Relation.from_link(nil, :self, hash)
       map << rel
 
-      assert_equal "{:self_url=>\"/users/1\"}", map.inspect
+      assert_equal "{:self_url=>\"/users/1\"}", map.inspect.strip
     end
   end
 end

--- a/test/relation_test.rb
+++ b/test/relation_test.rb
@@ -68,7 +68,6 @@ module Sawyer
       assert_equal [], rels.keys
     end
 
-    require 'pp'
     def test_relation_api_calls
       agent = Sawyer::Agent.new "http://foo.com/a/" do |conn|
         conn.builder.handlers.delete(Faraday::Adapter::NetHttp)

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -180,7 +180,7 @@ module Sawyer
 
     def test_inspect
       resource = Resource.new @agent, :a => 1
-      assert_equal "{:a=>1}", resource.inspect
+      assert_equal "{:a=>1}", resource.inspect.strip
     end
 
     def test_each


### PR DESCRIPTION
This updates the relation tests to send `options` arguments.