### PR TITLE
Handle relation types with dashes and URLs

### DIFF
--- a/lib/sawyer/response.rb
+++ b/lib/sawyer/response.rb
@@ -24,7 +24,7 @@ module Sawyer
 
     def data
       @data ||= begin
-        return(body) unless (headers[:content_type] =~ /json|msgpack/) 
+        return(body) unless (headers[:content_type] =~ /json|msgpack/)
         process_data(agent.decode_body(body))
       end
     end
@@ -49,7 +49,7 @@ module Sawyer
     # Returns an array of Relations
     def process_rels
       links = ( @headers["Link"] || "" ).split(', ').map do |link|
-        href, name = link.match(/<(.*?)>; rel="(\w+)"/).captures
+        href, name = link.match(/<(.*?)>; rel="(.+?)"/).captures
 
         [name.to_sym, Relation.from_link(@agent, name, :href => href)]
       end

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -24,6 +24,17 @@ module Sawyer
             emails = %w(rick@example.com technoweenie@example.com)
             [200, {'Content-Type' => 'application/json'}, Sawyer::Agent.encode(emails)]
           end
+
+          stub.get '/link_relations' do
+            [
+              200,
+              {
+                'Content-Type' => 'application/json',
+                'Link' =>  '</link_relations?page=2>; rel="next", </starred?page=19>; rel="last", </blog_post>; rel="with-dashes"; type="type="text/html", </>; rel="http://example.net/foo"'
+              },
+              {}
+            ]
+          end
         end
       end
 
@@ -81,6 +92,12 @@ module Sawyer
       res = @agent.call(:get, '/emails')
       assert_equal 'rick@example.com', res.data.first
     end
+
+    def test_link_relations
+      res = @agent.call(:get, '/link_relations')
+
+      assert_equal "/", res.rels[:"http://example.net/foo"].href
+      assert_equal "/blog_post", res.rels[:"with-dashes"].href
+    end
   end
 end
-


### PR DESCRIPTION
Link relations are not always matchable by `\w*`. [Examples](https://tools.ietf.org/html/rfc5988#section-5.5)

[The RFC](https://tools.ietf.org/html/rfc5988#section-5) defines the grammar as:

```
  relation-type  = reg-rel-type | ext-rel-type
  reg-rel-type   = LOALPHA *( LOALPHA | DIGIT | "." | "-" )
  ext-rel-type   = URI
```

But I have kept the regex as open as possible in the spirit of [Postel's Law](https://en.wikipedia.org/wiki/Robustness_principle) 💃 

cc @ahoglung