### PR TITLE
Specify correct minimal Faraday version

### DIFF
--- a/.gemfiles/faraday-0.gemfile
+++ b/.gemfiles/faraday-0.gemfile
@@ -1,3 +1,0 @@
-eval_gemfile '../Gemfile'
-
-gem 'faraday', '~> 0.9'

--- a/.gemfiles/faraday-1.gemfile
+++ b/.gemfiles/faraday-1.gemfile
@@ -1,3 +1,0 @@
-eval_gemfile '../Gemfile'
-
-gem 'faraday', '~> 1.0'

--- a/.gemfiles/faraday-2.gemfile
+++ b/.gemfiles/faraday-2.gemfile
@@ -1,3 +1,0 @@
-eval_gemfile '../Gemfile'
-
-gem 'faraday', '~> 2.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      BUNDLE_GEMFILE: ${{ github.workspace }}/.gemfiles/${{ matrix.gemfile }}.gemfile
+      FARADAY_VERSION: ${{ matrix.faraday }}
     strategy:
       fail-fast: false
       matrix:
         ruby: [ '2.6', '2.7', '3.0', '3.1', 'truffleruby', 'jruby' ]
-        gemfile: [ 'faraday-0', 'faraday-1', 'faraday-2' ]
+        faraday: [ '~> 0.17.3', '~> 1.0', '~> 2.0' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,12 @@ source "http://rubygems.org"
 
 gemspec
 
-gem 'rake'
+gem "rake"
 
 group :test do
   gem "minitest"
+end
+
+install_if -> { ENV["FARADAY_VERSION"] } do
+  gem "faraday", ENV["FARADAY_VERSION"]
 end

--- a/sawyer.gemspec
+++ b/sawyer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/lostisland/sawyer'
   spec.licenses = ['MIT']
 
-  spec.add_dependency 'faraday', ">= 0.9", "< 3"
+  spec.add_dependency 'faraday', '>= 0.17.3', '< 3'
   spec.add_dependency 'addressable', ['>= 2.3.5']
 
   spec.files = %w(Gemfile LICENSE.md README.md Rakefile)


### PR DESCRIPTION
This PR fixes minimal Faraday version.

Running tests with Faraday < 0.16, and 0.17.0-0.17.2 raises the following error:

```
faraday-0.15.4/lib/faraday/options.rb:166:in `new': tried to create Proc object without a block (ArgumentError)
```

But I would suggest restricting Faraday with `>= 1.0` since 0.16.x release was rolled back: https://github.com/lostisland/faraday/issues/1049