### PR TITLE
Add `dig` and `fetch` to `Sawyer::Resource`

### DIFF
--- a/lib/sawyer/resource.rb
+++ b/lib/sawyer/resource.rb
@@ -1,9 +1,12 @@
+require 'forwardable'
+
 module Sawyer
   class Resource
     SPECIAL_METHODS = Set.new(%w(agent rels fields))
     attr_reader :_agent, :_rels, :_fields
     attr_reader :attrs
     include Enumerable
+    extend Forwardable
 
     # Initializes a Resource with the given data.
     #
@@ -68,6 +71,8 @@ module Sawyer
     rescue NoMethodError
       nil
     end
+
+    def_delegators :attrs, :dig, :fetch
 
     ATTR_SETTER    = '='.freeze
     ATTR_PREDICATE = '?'.freeze

--- a/test/resource_test.rb
+++ b/test/resource_test.rb
@@ -22,6 +22,25 @@ module Sawyer
       assert res.fields.include?(:a)
     end
 
+    def test_dig
+      res = Resource.new @agent, :a => {:b => 1},
+        :_links => {:self => {:href => '/'}}
+
+      assert_equal 1, res.dig(:a, :b)
+      assert_nil res.dig(:a, :c)
+      assert_nil res.dig(:a, :c, :d)
+    end
+
+    def test_fetch
+      res = Resource.new @agent, :a => 1,
+        :_links => {:self => {:href => '/'}}
+
+      assert_equal 1, res.fetch(:a)
+      assert_equal 2, res.fetch(:b, 2)
+      assert_equal 3, res.fetch(:b) { 3 }
+      assert_raises(KeyError) { res.fetch(:b) }
+    end
+
     def test_clashing_keys
       res = Resource.new @agent, :agent => 1, :rels => 2, :fields => 3,
         :_links => {:self => {:href => '/'}}


### PR DESCRIPTION
These convenience methods make it easier to work with `Resource`s as a consumer, especially when they come from APIs that have a lot of nesting. My particular motivation comes from using [Octokit](https://github.com/octokit/octokit.rb), which returns `Sawyer::Resource`s, and I routinely try to `dig` or `fetch` from them, at which point my code blows up, and I don't want to convert the whole thing to a hash to get just the one bit of data I need.

Supporting these methods, in addition to `[]`, `[]=`, `each`, and all the other enumerable methods, allows consumers to treat a `Sawyer::Resource` effectively as a Hash for the attributes without having to convert it to one and lose the extra behavior that the `Resource` provides.